### PR TITLE
Added messier_object_detail template, and routing

### DIFF
--- a/frontend/urls.py
+++ b/frontend/urls.py
@@ -8,5 +8,5 @@ from frontend import views
 urlpatterns = [
     path('', views.index, name='index'),
     path('messier_objects', views.mes_obj_overview, name='mes_obj_overview'),
-    path('messier_object_detail', views.mes_obj_detail, name='mes_obj_detail')
+    path('messier_object_detail/<int:mes_num>', views.mes_obj_detail, name='mes_obj_detail')
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/frontend/views.py
+++ b/frontend/views.py
@@ -1,4 +1,4 @@
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404
 
 from messier_objects.models import MessierObject
 
@@ -18,10 +18,10 @@ def mes_obj_overview(request):
 
 
 def mes_obj_detail(request, mes_num):
-    mes_obj = MessierObject.objects.filter(messier_number=mes_num)
+    mes_obj = get_object_or_404(MessierObject, messier_number=mes_num)
 
     context = {
         "mes_obj": mes_obj
     }
     
-    return render(request, 'api_frontends/messier_objects_overview.html', context)
+    return render(request, 'api_frontends/messier_object_detail.html', context)

--- a/templates/api_frontends/messier_object_detail.html
+++ b/templates/api_frontends/messier_object_detail.html
@@ -1,0 +1,31 @@
+{% extends 'base.html' %}
+
+{% block content %}
+
+<h1>messier_object_detail.html</h1>
+<br>
+<hr>
+<h3>M{{ mes_obj.messier_number }} - 
+    {% if mes_obj.name == '–' %}
+        No Name</h3>
+    {% else %}
+        {{ mes_obj.name }}</h3>
+    {% endif %}
+<h4>NCG / IC Number: {{ mes_obj.ncg_or_ic_number }}</h4>
+<h5>Object Type: {{ mes_obj.object_type }}</h5>
+<br>
+<p>Distance in KLY: {{ mes_obj.distance_kly }}</p>
+<p>Constellation: {{ mes_obj.constellation }}</p>
+<p>Apparent Magnitude: {{ mes_obj.apparent_magnitude }}</p>
+<br>
+{% if mes_obj.photo %}
+    <img src="{{ mes_obj.photo.url }}">
+{% else %}
+    <img src='/media/notcaptured.JPG'>
+{% endif %}
+<br>
+<hr>
+
+
+
+{% endblock %}

--- a/templates/api_frontends/messier_objects_overview.html
+++ b/templates/api_frontends/messier_objects_overview.html
@@ -13,7 +13,8 @@
             {{ mes_obj.name }}</h3>
         {% endif %}
     <h4>NCG / IC Number: {{ mes_obj.ncg_or_ic_number }}</h4>
-    <h5>{{ mes_obj.object_type }}</h5>
+    <h5>Object Type: {{ mes_obj.object_type }}</h5>
+    <br>
     <p>Distance in KLY: {{ mes_obj.distance_kly }}</p>
     <p>Constellation: {{ mes_obj.constellation }}</p>
     <p>Apparent Magnitude: {{ mes_obj.apparent_magnitude }}</p>

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,9 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
-
-    <!-- My Custom CSS -->
-    <link rel="stylesheet" href="{% static 'blog/css/123.css' %}">
     <title>AstroPhoto</title>
   </head>
   <body>


### PR DESCRIPTION
- Removed an incorrect css import.
- Added a URL parameter for messier_object_detail, passing the object's name (Which is a number).
- Changed the mes_obj_detail view to try to get the object from the database or return a 404.
- Put the correct template in the render of mes_obj_detail view.
- Added "Object Type: " before displaying the messier object type in both the overview and detail templates.